### PR TITLE
refactor: Airflow 웹 서버에서 Fargate에 대한 공용 IP 가져오기 수정

### DIFF
--- a/.github/workflows/deploy-to-ecr-and-ecs.yml
+++ b/.github/workflows/deploy-to-ecr-and-ecs.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           TASK_ARN=$(aws ecs list-tasks --cluster ${{ env.ECS_CLUSTER }} --service-name lulu-airflow-web-server --query taskArns[0] --output text) || echo "TASK_ARN failed"
           CONTAINER_INSTANCE=$(aws ecs describe-tasks --cluster ${{ env.ECS_CLUSTER }} --tasks $TASK_ARN --query tasks[0].containerInstanceArn --output text) || echo "CONTAINER_INSTANCE failed"
-          EC2_INSTANCE_ID=$(aws ecs describe-container-instances --cluster ${{ env.ECS_CLUSTER }} --container-instances $CONTAINER_INSTANCE --query containerInstances[0].ec2InstanceId --output text) || echo "EC2_INSTANCE_ID failed"
+          EC2_INSTANCE_ID=$(aws ecs describe-container-instances --cluster ${{ env.ECS_CLUSTER }} --container-instances $CONTAINER_INSTANCE --query 'containerInstances[0].ec2InstanceId' --output text) || echo "EC2_INSTANCE_ID failed"
           echo "EC2_INSTANCE_ID: $EC2_INSTANCE_ID"
           PUBLIC_IP=$(aws ec2 describe-instances --instance-ids $EC2_INSTANCE_ID --query Reservations[0].Instances[0].PublicIpAddress --output text) || echo "PUBLIC_IP failed"
           echo "PUBLIC_IP=$PUBLIC_IP" >> $GITHUB_ENV

--- a/.github/workflows/deploy-to-ecr-and-ecs.yml
+++ b/.github/workflows/deploy-to-ecr-and-ecs.yml
@@ -4,10 +4,8 @@ on:
   push:
     paths:
       - 'src/airflow/**'
-      - '.github/workflows/**' # todo 삭제
     branches:
       - main
-      - test-cd # todo 삭제
 
 env:
   AWS_REGION: ap-northeast-3
@@ -16,7 +14,7 @@ env:
 
 jobs:
   deploy:
-    # if: github.repository == 'data-engineering-team4/Lulu'
+    if: github.repository == 'data-engineering-team4/Lulu'
     name: Deploy
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy-to-ecr-and-ecs.yml
+++ b/.github/workflows/deploy-to-ecr-and-ecs.yml
@@ -94,11 +94,11 @@ jobs:
       - name: Fetch Public IP for Airflow Webserver
         id: fetch-ip
         run: |
-          TASK_ARN=$(aws ecs list-tasks --cluster ${{ env.ECS_CLUSTER }} --service-name lulu-airflow-web-server --query taskArns[0] --output text)
-          CONTAINER_INSTANCE=$(aws ecs describe-tasks --cluster ${{ env.ECS_CLUSTER }} --tasks $TASK_ARN --query tasks[0].containerInstanceArn --output text)
-          EC2_INSTANCE_ID=$(aws ecs describe-container-instances --cluster ${{ env.ECS_CLUSTER }} --container-instances $CONTAINER_INSTANCE --query containerInstances[0].ec2InstanceId --output text)
+          TASK_ARN=$(aws ecs list-tasks --cluster ${{ env.ECS_CLUSTER }} --service-name lulu-airflow-web-server --query taskArns[0] --output text) || echo "TASK_ARN failed"
+          CONTAINER_INSTANCE=$(aws ecs describe-tasks --cluster ${{ env.ECS_CLUSTER }} --tasks $TASK_ARN --query tasks[0].containerInstanceArn --output text) || echo "CONTAINER_INSTANCE failed"
+          EC2_INSTANCE_ID=$(aws ecs describe-container-instances --cluster ${{ env.ECS_CLUSTER }} --container-instances $CONTAINER_INSTANCE --query containerInstances[0].ec2InstanceId --output text) || echo "EC2_INSTANCE_ID failed"
           echo "EC2_INSTANCE_ID: $EC2_INSTANCE_ID"
-          PUBLIC_IP=$(aws ec2 describe-instances --instance-ids $EC2_INSTANCE_ID --query Reservations[0].Instances[0].PublicIpAddress --output text)
+          PUBLIC_IP=$(aws ec2 describe-instances --instance-ids $EC2_INSTANCE_ID --query Reservations[0].Instances[0].PublicIpAddress --output text) || echo "PUBLIC_IP failed"
           echo "PUBLIC_IP=$PUBLIC_IP" >> $GITHUB_ENV
 
       - name: Set Slack Message

--- a/.github/workflows/deploy-to-ecr-and-ecs.yml
+++ b/.github/workflows/deploy-to-ecr-and-ecs.yml
@@ -4,8 +4,10 @@ on:
   push:
     paths:
       - 'src/airflow/**'
+      - '.github/workflows/**' # todo 삭제
     branches:
       - main
+      - test-cd # todo 삭제
 
 env:
   AWS_REGION: ap-northeast-3
@@ -14,7 +16,7 @@ env:
 
 jobs:
   deploy:
-    if: github.repository == 'data-engineering-team4/Lulu'
+    # if: github.repository == 'data-engineering-team4/Lulu'
     name: Deploy
     runs-on: ubuntu-latest
 
@@ -95,6 +97,7 @@ jobs:
           TASK_ARN=$(aws ecs list-tasks --cluster ${{ env.ECS_CLUSTER }} --service-name lulu-airflow-web-server --query taskArns[0] --output text)
           CONTAINER_INSTANCE=$(aws ecs describe-tasks --cluster ${{ env.ECS_CLUSTER }} --tasks $TASK_ARN --query tasks[0].containerInstanceArn --output text)
           EC2_INSTANCE_ID=$(aws ecs describe-container-instances --cluster ${{ env.ECS_CLUSTER }} --container-instances $CONTAINER_INSTANCE --query containerInstances[0].ec2InstanceId --output text)
+          echo "EC2_INSTANCE_ID: $EC2_INSTANCE_ID"
           PUBLIC_IP=$(aws ec2 describe-instances --instance-ids $EC2_INSTANCE_ID --query Reservations[0].Instances[0].PublicIpAddress --output text)
           echo "PUBLIC_IP=$PUBLIC_IP" >> $GITHUB_ENV
 

--- a/.github/workflows/deploy-to-ecr-and-ecs.yml
+++ b/.github/workflows/deploy-to-ecr-and-ecs.yml
@@ -94,12 +94,10 @@ jobs:
       - name: Fetch Public IP for Airflow Webserver
         id: fetch-ip
         run: |
-          TASK_ARN=$(aws ecs list-tasks --cluster ${{ env.ECS_CLUSTER }} --service-name lulu-airflow-web-server --query taskArns[0] --output text) || echo "TASK_ARN failed"
-          CONTAINER_INSTANCE=$(aws ecs describe-tasks --cluster ${{ env.ECS_CLUSTER }} --tasks $TASK_ARN --query tasks[0].containerInstanceArn --output text) || echo "CONTAINER_INSTANCE failed"
-          EC2_INSTANCE_ID=$(aws ecs describe-container-instances --cluster ${{ env.ECS_CLUSTER }} --container-instances $CONTAINER_INSTANCE --query 'containerInstances[0].ec2InstanceId' --output text) || echo "EC2_INSTANCE_ID failed"
-          echo "EC2_INSTANCE_ID: $EC2_INSTANCE_ID"
-          PUBLIC_IP=$(aws ec2 describe-instances --instance-ids $EC2_INSTANCE_ID --query Reservations[0].Instances[0].PublicIpAddress --output text) || echo "PUBLIC_IP failed"
-          echo "PUBLIC_IP=$PUBLIC_IP" >> $GITHUB_ENV
+          TASK_ARN=$(aws ecs list-tasks --cluster ${{ env.ECS_CLUSTER }} --service-name lulu-airflow-web-server --query 'taskArns[0]' --output text) || echo "TASK_ARN failed"
+          NETWORK_INTERFACE_ID=$(aws ecs describe-tasks --cluster ${{ env.ECS_CLUSTER }} --tasks $TASK_ARN --query 'tasks[0].attachments[0].details[?name==`networkInterfaceId`].value' --output text) || echo "NETWORK_INTERFACE_ID failed"
+          PUBLIC_IP=$(aws ec2 describe-network-interfaces --network-interface-ids $NETWORK_INTERFACE_ID --query 'NetworkInterfaces[0].Association.PublicIp' --output text) || echo "PUBLIC_IP failed"
+          echo "PUBLIC_IP=$PUBLIC_IP:8080" >> $GITHUB_ENV
 
       - name: Set Slack Message
         run: |


### PR DESCRIPTION
## Type of PR (check all applicable)

<!-- 해당되는 Pull Request 타입에 모두 체크해주세요. -->
<!-- 체크 시 "-[x]" 이렇게 x 표시 하면 됩니다.  -->
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert


## Description
<!-- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 등 최대한 상세하게 적어주세요. -->

Airflow Web Server의 Public IP를 가져오는 로직을 AWS Fargate 환경에 맞게 수정했습니다.
원래는 EC2 인스턴스를 통해 Public IP를 가져오는 로직이었으나, 우리의 환경에서는 Fargate를 사용하고 있습니다. Fargate의 경우에는 EC2 인스턴스 정보가 없으므로, 대신 태스크의 네트워크 인터페이스에서 Public IP를 가져오도록 쿼리를 수정했습니다.


## Related Tickets & Documents
<!--
이슈와 관련된 PR을 작성하는 경우, 아래에 포함해 주세요.
[Github의 이슈에 풀 리퀘스트 연결하는 방법](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)을 따르는 것이 좋습니다.

예를 들어 "closes #1234"라는 텍스트는 현재 풀 리퀘스트를 이슈 1234에 연결합니다. 그리고 PR를 병합하면 Github가 이슈를 자동으로 닫습니다.
-->

- Related Issue #50 
- Closes #


## Test Result
<!-- ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 
결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->

AWS CLI 환경에서 query문을 실행하고 확인한 뒤에 Github Actions config를 변경했습니다.
1. ECS 클러스터 설정을 Fargate로 확인합니다.
2. GitHub Actions을 실행하여 새로운 로직이 Public IP 정보를 정확히 가져오는지 확인합니다.
<img width="1711" alt="스크린샷 2023-08-27 오후 5 22 02" src="https://github.com/data-engineering-team4/Lulu/assets/79040336/d795497a-1790-47ff-b695-c5c43cfd48c5">


## Reference
<!-- 참고할 사항이 있다면 적어주세요. 또는 새로 알게 된 내용이나 궁금한 사항들 자유롭게 적어주세요. -->